### PR TITLE
ACPI/PM: Propagate power button event to user space when device wakes up

### DIFF
--- a/drivers/acpi/button.c
+++ b/drivers/acpi/button.c
@@ -38,6 +38,10 @@
 #define ACPI_BUTTON_DEVICE_NAME_LID	"Lid Switch"
 #define ACPI_BUTTON_TYPE_LID		0x05
 
+/* does userspace want to see KEY_POWER at resume? */
+static bool __read_mostly key_power_at_resume = true;
+module_param(key_power_at_resume, bool, 0644);
+
 enum {
 	ACPI_BUTTON_LID_INIT_IGNORE,
 	ACPI_BUTTON_LID_INIT_OPEN,
@@ -441,7 +445,7 @@ static void acpi_button_notify(acpi_handle handle, u32 event, void *data)
 	acpi_pm_wakeup_event(&device->dev);
 
 	button = acpi_driver_data(device);
-	if (button->suspended)
+	if (button->suspended && !key_power_at_resume)
 		return;
 
 	input = button->input;

--- a/drivers/acpi/sleep.c
+++ b/drivers/acpi/sleep.c
@@ -454,6 +454,12 @@ static int acpi_pm_prepare(void)
 	return error;
 }
 
+static void pwr_btn_notify(struct acpi_device *device)
+{
+	struct acpi_driver *acpi_drv = to_acpi_driver(device->dev.driver);
+	acpi_drv->ops.notify(device, ACPI_FIXED_HARDWARE_EVENT);
+}
+
 /**
  *	acpi_pm_finish - Instruct the platform to leave a sleep state.
  *
@@ -496,6 +502,7 @@ static void acpi_pm_finish(void)
 						    NULL, -1);
 	if (pwr_btn_adev) {
 		pm_wakeup_event(&pwr_btn_adev->dev, 0);
+		pwr_btn_notify(pwr_btn_adev);
 		acpi_dev_put(pwr_btn_adev);
 	}
 }


### PR DESCRIPTION
Sometimes power button does not wake up the systemm and we get suspends event right after that. Here Android needs to see KEY_POWER at resume. Otherwise, its opportunistic suspend will kick in shortly.

However, other OS such as Ubuntu doesn't like KEY_POWER at resume. So add a knob "/sys/module/button/parameters/key_power_at_resume" for users to select.