### PR TITLE
Enable usb role switch

### DIFF
--- a/drivers/usb/host/xhci-ext-caps.c
+++ b/drivers/usb/host/xhci-ext-caps.c
@@ -14,6 +14,10 @@
 #define USB_SW_RESOURCE_SIZE	0x400
 
 #define PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI	0x22b5
+#define PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_XHCI    0xa71e
+#define PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI 0x51ed
+
+#define INTEL_EXTENDED_CAP_DAP_OFFSET 0x8900
 
 static const struct property_entry role_switch_props[] = {
 	PROPERTY_ENTRY_BOOL("sw_switch_disable"),
@@ -41,7 +45,13 @@ static int xhci_create_intel_xhci_sw_pdev(struct xhci_hcd *xhci, u32 cap_offset)
 		return -ENOMEM;
 	}
 
-	res.start = hcd->rsrc_start + cap_offset;
+	if (pci->device == PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_XHCI ||
+	    pci->device == PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI) {
+		/* Extended cap for role switch starts at 0x8900 */
+		res.start = hcd->rsrc_start + INTEL_EXTENDED_CAP_DAP_OFFSET;
+	} else {
+		res.start = hcd->rsrc_start + cap_offset;
+	}
 	res.end	  = res.start + USB_SW_RESOURCE_SIZE - 1;
 	res.name  = USB_SW_DRV_NAME;
 	res.flags = IORESOURCE_MEM;
@@ -53,7 +63,9 @@ static int xhci_create_intel_xhci_sw_pdev(struct xhci_hcd *xhci, u32 cap_offset)
 		return ret;
 	}
 
-	if (pci->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI) {
+	if (pci->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI ||
+		pci->device == PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_XHCI ||
+		pci->device == PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI) {
 		ret = device_create_managed_software_node(&pdev->dev, role_switch_props,
 							  NULL);
 		if (ret) {

--- a/drivers/usb/host/xhci-pci.c
+++ b/drivers/usb/host/xhci-pci.c
@@ -62,6 +62,7 @@
 #define PCI_DEVICE_ID_INTEL_MAPLE_RIDGE_XHCI		0x1138
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI		0x51ed
 #define PCI_DEVICE_ID_INTEL_ALDER_LAKE_N_PCH_XHCI	0x54ed
+#define PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_XHCI 0xa71e
 
 #define PCI_DEVICE_ID_AMD_RENOIR_XHCI			0x1639
 #define PCI_DEVICE_ID_AMD_PROMONTORYA_4			0x43b9
@@ -427,6 +428,8 @@ static void xhci_pci_quirks(struct device *dev, struct xhci_hcd *xhci)
 	if (pdev->vendor == PCI_VENDOR_ID_INTEL &&
 	    (pdev->device == PCI_DEVICE_ID_INTEL_CHERRYVIEW_XHCI ||
 	     pdev->device == PCI_DEVICE_ID_INTEL_SUNRISEPOINT_LP_XHCI ||
+		 pdev->device == PCI_DEVICE_ID_INTEL_RAPTOR_LAKE_XHCI ||
+		 pdev->device == PCI_DEVICE_ID_INTEL_ALDER_LAKE_PCH_XHCI ||
 	     pdev->device == PCI_DEVICE_ID_INTEL_APL_XHCI))
 		xhci->quirks |= XHCI_INTEL_USB_ROLE_SW;
 	if (pdev->vendor == PCI_VENDOR_ID_INTEL &&


### PR DESCRIPTION
Enabled platform support for USB role switch
between device and host modes on the same USB port.

Tracked-On: OAM-127425