### PR TITLE
Add metadata transfer feature for raw sensor

### DIFF
--- a/include/uapi/linux/virtio_camera.h
+++ b/include/uapi/linux/virtio_camera.h
@@ -26,6 +26,11 @@ enum virtio_camera_ctrl_type {
 	VIRTIO_CAMERA_CMD_ENUM_INTV,
 	VIRTIO_CAMERA_CMD_FREEZE,
 	VIRTIO_CAMERA_CMD_RESTORE,
+	VIRTIO_CAMERA_CMD_GET_CTRL,
+	VIRTIO_CAMERA_CMD_QUERY_EXT_CTRL,
+	VIRTIO_CAMERA_CMD_SET_CTRL,
+	VIRTIO_CAMERA_CMD_SET_EXT_CTRLS,
+	VIRTIO_CAMERA_CMD_QUERY_CTRL,
 
 	VIRTIO_CAMERA_CMD_RESP_OK_NODATA = 0x100,
 
@@ -81,14 +86,31 @@ struct virtio_camera_req_buffer {
 	__le64 timestamp;
 };
 
+struct virtio_camera_req_ctrl {
+    __u32 id;            // Control ID
+    __u32 type;          // Control type (e.g., boolean, integer, etc.)
+    __s32 value;         // Current value of the control
+    __u32 minimum;       // Minimum value for the control
+    __u32 maximum;       // Maximum value for the control
+    __u32 step;          // Step size for the control
+    __u32 default_value; // Default value for the control
+    __u32 flags;         // Flags indicating control properties (e.g., read-only)
+};
+
+struct virtio_camera_req_ext_ctrls {
+	__u32 count;
+	struct virtio_camera_req_ctrl controls[];
+};
+
 struct virtio_camera_op_ctrl_req {
 	struct virtio_camera_ctrl_hdr header;
 
 	union {
 		struct virtio_camera_req_format format;
 		struct virtio_camera_req_buffer buffer;
+		struct virtio_camera_req_ctrl ctrl;
+		struct virtio_camera_req_ext_ctrls ext_ctrls; 
 		__le64 padding[3];
 	} u;
 };
-
 #endif


### PR DESCRIPTION
This patch has added interface in the virtio camera module to implement the metadata transfer feature for raw sensor.

Test Done:
1 3A Metadata Set & Get
2 AAOS14 system boot/reboot

Tracked-On: OAM-131713