### PR TITLE
Change virtiocamera device node name.

### DIFF
--- a/drivers/media/platform/virtio/virtio-camera.c
+++ b/drivers/media/platform/virtio/virtio-camera.c
@@ -982,7 +982,7 @@ static int virtio_camera_setup_vnode(struct virtio_device *vdev,
 
 			vnode->ctr_vqx = &vcam->vqs[vq_idx++];
 
-			err = video_register_device(&vnode->vdev, VFL_TYPE_VIDEO, -1);
+			err = video_register_device(&vnode->vdev, VFL_TYPE_VIRTCAM, -1);
 
 			if (err) {
 				virtio_camera_unregister_devs(vcam, i, j-1);

--- a/drivers/media/v4l2-core/v4l2-dev.c
+++ b/drivers/media/v4l2-core/v4l2-dev.c
@@ -545,13 +545,17 @@ static void determine_valid_ioctls(struct video_device *vdev)
 			      V4L2_CAP_META_OUTPUT;
 	DECLARE_BITMAP(valid_ioctls, BASE_VIDIOC_PRIVATE);
 	const struct v4l2_ioctl_ops *ops = vdev->ioctl_ops;
-	bool is_vid = vdev->vfl_type == VFL_TYPE_VIDEO &&
+	bool is_vid = (vdev->vfl_type == VFL_TYPE_VIDEO ||
+			vdev->vfl_type == VFL_TYPE_UVC ||
+			vdev->vfl_type == VFL_TYPE_VIRTCAM) &&
 		      (vdev->device_caps & vid_caps);
 	bool is_vbi = vdev->vfl_type == VFL_TYPE_VBI;
 	bool is_radio = vdev->vfl_type == VFL_TYPE_RADIO;
 	bool is_sdr = vdev->vfl_type == VFL_TYPE_SDR;
 	bool is_tch = vdev->vfl_type == VFL_TYPE_TOUCH;
-	bool is_meta = vdev->vfl_type == VFL_TYPE_VIDEO &&
+	bool is_meta = (vdev->vfl_type == VFL_TYPE_VIDEO ||
+			vdev->vfl_type == VFL_TYPE_UVC ||
+			vdev->vfl_type == VFL_TYPE_VIRTCAM) &&
 		       (vdev->device_caps & meta_caps);
 	bool is_rx = vdev->vfl_dir != VFL_DIR_TX;
 	bool is_tx = vdev->vfl_dir != VFL_DIR_RX;
@@ -800,6 +804,8 @@ static int video_register_media_controller(struct video_device *vdev)
 	vdev->entity.function = MEDIA_ENT_F_UNKNOWN;
 
 	switch (vdev->vfl_type) {
+	case VFL_TYPE_VIRTCAM:
+	case VFL_TYPE_UVC:
 	case VFL_TYPE_VIDEO:
 		intf_type = MEDIA_INTF_T_V4L_VIDEO;
 		vdev->entity.function = MEDIA_ENT_F_IO_V4L;
@@ -908,6 +914,12 @@ int __video_register_device(struct video_device *vdev,
 
 	/* Part 1: check device type */
 	switch (type) {
+	case VFL_TYPE_VIRTCAM:
+		name_base = "virtvideo";
+		break;
+	case VFL_TYPE_UVC:
+		name_base = "uvcvideo";
+		break;
 	case VFL_TYPE_VIDEO:
 		name_base = "video";
 		break;
@@ -952,6 +964,8 @@ int __video_register_device(struct video_device *vdev,
 	 * of 128-191 and just pick the first free minor there
 	 * (new style). */
 	switch (type) {
+	case VFL_TYPE_VIRTCAM:
+	case VFL_TYPE_UVC:
 	case VFL_TYPE_VIDEO:
 		minor_offset = 0;
 		minor_cnt = 64;

--- a/drivers/media/v4l2-core/v4l2-ioctl.c
+++ b/drivers/media/v4l2-core/v4l2-ioctl.c
@@ -920,12 +920,16 @@ static int check_fmt(struct file *file, enum v4l2_buf_type type)
 			      V4L2_CAP_META_OUTPUT;
 	struct video_device *vfd = video_devdata(file);
 	const struct v4l2_ioctl_ops *ops = vfd->ioctl_ops;
-	bool is_vid = vfd->vfl_type == VFL_TYPE_VIDEO &&
+	bool is_vid = (vfd->vfl_type == VFL_TYPE_VIDEO ||
+			vfd->vfl_type == VFL_TYPE_UVC ||
+			vfd->vfl_type == VFL_TYPE_VIRTCAM) &&
 		      (vfd->device_caps & vid_caps);
 	bool is_vbi = vfd->vfl_type == VFL_TYPE_VBI;
 	bool is_sdr = vfd->vfl_type == VFL_TYPE_SDR;
 	bool is_tch = vfd->vfl_type == VFL_TYPE_TOUCH;
-	bool is_meta = vfd->vfl_type == VFL_TYPE_VIDEO &&
+	bool is_meta = (vfd->vfl_type == VFL_TYPE_VIDEO ||
+			vfd->vfl_type == VFL_TYPE_UVC ||
+			vfd->vfl_type == VFL_TYPE_VIRTCAM) &&
 		       (vfd->device_caps & meta_caps);
 	bool is_rx = vfd->vfl_dir != VFL_DIR_TX;
 	bool is_tx = vfd->vfl_dir != VFL_DIR_RX;

--- a/include/media/v4l2-dev.h
+++ b/include/media/v4l2-dev.h
@@ -40,6 +40,8 @@ enum vfl_devnode_type {
 	VFL_TYPE_SUBDEV,
 	VFL_TYPE_SDR,
 	VFL_TYPE_TOUCH,
+	VFL_TYPE_UVC,
+	VFL_TYPE_VIRTCAM,
 	VFL_TYPE_MAX /* Shall be the last one */
 };
 


### PR DESCRIPTION
Issue-Detailed: UVC camera messes up video device node sequence. So it's necessary to rearrange different types of camera device to their own device node names:
virtiocamera: /dev/virtvideo*
uvc camera: /dev/video*

Issue-Fixed: Define new v4l2 device type as VFL_TYPE_VIRTCAM whose name_base is 'virtvideo' and set virtiocamera device type as VIRTCAM.

Tested-On: /dev/virtvideo* created for virtiocamera devices. Those video camera devices can preview/capture/record.

Tracked-On: OAM-132104