### PR TITLE
drm/virtio: pass correct plane index to backend

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_display.c
+++ b/drivers/gpu/drm/virtio/virtgpu_display.c
@@ -403,6 +403,7 @@ static int vgdev_output_init(struct virtio_gpu_device *vgdev, int index)
 		output->info.r.width = cpu_to_le32(XRES_DEF);
 		output->info.r.height = cpu_to_le32(YRES_DEF);
 	}
+	output->plane_idx_offset = -1;
 
 	if(vgdev->has_scaling)
 		output->scaler_users = 0;

--- a/drivers/gpu/drm/virtio/virtgpu_drv.h
+++ b/drivers/gpu/drm/virtio/virtgpu_drv.h
@@ -215,6 +215,7 @@ struct virtio_gpu_output {
 	int cur_y;
 	bool needs_modeset;
 	int plane_num;
+	int plane_idx_offset;
 	uint64_t rotation[VIRTIO_GPU_MAX_PLANES];
 	unsigned scaler_users;
 	struct virtio_gpu_hdcp hdcp;


### PR DESCRIPTION
pass correct plane index to backend, plane index range of each output is 0 - MAX_PLANE.