### PR TITLE
drm/virtio: Use drm_err instead of WARN upon vblank timeout

### DIFF
--- a/drivers/gpu/drm/virtio/virtgpu_display.c
+++ b/drivers/gpu/drm/virtio/virtgpu_display.c
@@ -542,8 +542,9 @@ virtio_gpu_wait_for_vblanks(struct drm_device *dev,
 						drm_crtc_vblank_count(crtc)),
 				msecs_to_jiffies(100));
 
-		WARN(!ret, "[CRTC:%d:%s] vblank wait timed out\n",
-		     crtc->base.id, crtc->name);
+		if (!ret)
+			drm_err(dev, "[CRTC:%d:%s] vblank wait timed out\n",
+				crtc->base.id, crtc->name);
 
 		drm_crtc_vblank_put(crtc);
 	}


### PR DESCRIPTION
Kernel warning upon atomic commit timeout is terrifying compared with the harm it does ... Let's switch over to print a error message instead.

Tracked-On: OAM-132674