### PR TITLE
Add udm synchronization between BE and FE.

### DIFF
--- a/drivers/virtio/virtio_guest_shm.c
+++ b/drivers/virtio/virtio_guest_shm.c
@@ -130,17 +130,11 @@ static int virtio_ivshmem_probe(struct pci_dev *pci_dev,
 	vi_dev->notify_peer = virtio_guest_shm_notify_peer;
 	vi_dev->early_irq_handler = virtio_guest_shm_early_irq_handler;
 	vi_dev->priv = vi_data;
+	vi_dev->virtio_registered = false;
 
 	ret = virtio_shmem_probe(vi_dev);
 	if (ret)
 		goto err_enable;
-
-	ret = register_virtio_device(&vi_dev->vdev);
-	if (ret) {
-		dev_err(&pci_dev->dev, "failed to register device\n");
-		put_device(&vi_dev->vdev.dev);
-		goto err_enable;
-	}
 
 #ifdef CONFIG_VIRTIO_IVSHMEM_DEBUG
 	vi_dev->shmem_sz_used = (vi_dev->virtio_header->size
@@ -166,7 +160,7 @@ static void virtio_ivshmem_remove(struct pci_dev *pci_dev)
 	struct virtio_shmem_device *vi_dev = pci_get_drvdata(pci_dev);
 	struct device *dev = get_device(&vi_dev->vdev.dev);
 
-	unregister_virtio_device(&vi_dev->vdev);
+	virtio_shmem_remove(vi_dev);
 	pci_disable_device(pci_dev);
 	put_device(dev);
 	kfree(vi_dev);

--- a/drivers/virtio/virtio_shmem.h
+++ b/drivers/virtio/virtio_shmem.h
@@ -7,6 +7,13 @@
 #include <linux/virtio.h>
 #include <linux/virtio_pci.h>
 
+#define VIRTIO_SHMEM_IOCTL_TYPE	0xA3
+
+#define VIRTIO_SHMEM_IOCTL_AUTO_REMOVE		\
+	_IOW(VIRTIO_SHMEM_IOCTL_TYPE, 0x1, int)
+#define VIRTIO_SHMEM_IOCTL_UNREGISTER		\
+	_IO(VIRTIO_SHMEM_IOCTL_TYPE, 0x2)
+
 struct virtio_shmem_header {
 	__le32 revision;
 	__le32 size;
@@ -22,7 +29,8 @@ struct virtio_shmem_header {
 	};
 	__u8 config_event;
 	__u8 queue_event;
-	__u8 __rsvd[2];
+	__u8 max_vector;
+	__u8 __rsvd[1];
 	union {
 		__le32 frontend_status;
 		struct {
@@ -37,12 +45,21 @@ struct virtio_shmem_header {
 			__le16 backend_id;
 		};
 	};
+	union {
+		__le32 handshake;
+		struct {
+			__le16 handshake_mask;
+			__le16 backend_rand;
+		};
+	};
 
 	struct virtio_pci_common_cfg common_config;
 	__u8 config[];
 };
 
 struct virtio_shmem_device {
+	struct module *owner;
+	struct device dev;
 	struct virtio_device vdev;
 	struct pci_dev *pci_dev;
 
@@ -50,6 +67,7 @@ struct virtio_shmem_device {
 	bool per_vq_vector;
 	char *config_irq_name;
 	char *queues_irq_name;
+	char *event_irq_name;
 
 	u32 this_id;
 	u32 peer_id;
@@ -71,6 +89,14 @@ struct virtio_shmem_device {
 	void (*notify_peer)(struct virtio_shmem_device *vi_dev, unsigned int vector);
 	irqreturn_t (*early_irq_handler)(struct virtio_shmem_device *vi_dev);
 
+	bool virtio_registered;
+	bool virtio_removed;
+	unsigned short backend_rand;
+	int auto_unregister;
+	struct delayed_work shmem_handshake_work;
+
+	int	minor;
+
 	void *priv;
 #ifdef CONFIG_VIRTIO_IVSHMEM_DEBUG
 	resource_size_t shmem_sz_used;
@@ -82,6 +108,11 @@ struct virtio_shmem_device {
 #endif
 };
 
+struct virtio_shmem_user {
+	struct virtio_shmem_device	*vi_dev;
+};
+
 int virtio_shmem_probe(struct virtio_shmem_device *vi_dev);
+void virtio_shmem_remove(struct virtio_shmem_device *vi_dev);
 
 #endif /* _DRIVERS_VIRTIO_VIRTIO_SHMEM_H */


### PR DESCRIPTION
1. Add handshake. When the VM which UDM run in shutdown and BE do not have change to notify FE, running FE can know the BE status change by check handshake mask.
The handshake mask lays in virtio header in share memory BAR. It is checked every 2 seconds.
2. Add event interrupt. When the backend application exits normally or the VM where the backend resides is shut down normally, BE can trigger a interrupt, and notify FE the event.
3. Create /dev/virtio_shmemX which set auto or manual unresigter virtio device by 'VIRTIO_SHMEM_IOCTL_AUTO_REMOVE'. In this state, APP in user space can unregister the device by 'VIRTIO_SHMEM_IOCTL_UNREGISTER'.